### PR TITLE
docs: Update README.md about hackathon related info

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -18,7 +18,7 @@ We develop and maintain open source SDKs related to NEM/Symbol.
 We plan various community events and create websites and web apps for those events.
 
 - Hackathon
-  - Event Website([2023 GitHub](https://github.com/nemtus/hackathon-lp-2023), [2023 Website](https://hackathon-2023.nemtus.com/))
+  - Event Website([GitHub](https://github.com/nemtus/hackathon-lp), [Website](https://hackathon.nemtus.com/), [2024 GitHub](https://github.com/nemtus/hackathon-lp-2024), [2024 Website](https://hackathon-2024.nemtus.com/), [2023 GitHub](https://github.com/nemtus/hackathon-lp-2023), [2023 Website](https://hackathon-2023.nemtus.com/))
   - Event Management Web App with Symbol Blockchain([GitHub](https://github.com/nemtus/hackathon), [Web App](https://nemtus-hackathon.web.app/))
 
 - Tech Fest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated links to the event website and GitHub repositories for the 2023 and 2024 Hackathon events in the project README.
  - Refreshed the web app's GitHub repository link for improved accessibility and user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->