### PR TITLE
chore: Add Claude Code config and ignore .op/

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,41 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git add:*)",
+      "Bash(ls:*)",
+      "Bash(find:*)",
+      "Bash(rg:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh repo view:*)",
+      "Edit(*.md)",
+      "Edit(profile/*.md)",
+      "Edit(*.yml)",
+      "Edit(*.yaml)"
+    ],
+    "ask": [
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr merge:*)",
+      "WebFetch"
+    ],
+    "deny": [
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(git clean:*)",
+      "Bash(rm -rf:*)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./**/secrets/**)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# 1Password CLI shell plugins (local tooling state)
+.op/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repository is
+
+This is the NEMTUS organization's special `.github` repository. GitHub treats it as a source of
+**organization-wide defaults**, not as an application. There is no build, test, or lint tooling —
+changes are plain text/config files that GitHub renders or applies automatically.
+
+NEMTUS is a non-profit promoting the NEM/Symbol blockchain. The org's actual code (SDKs, event
+web apps, blogs) lives in *other* repositories linked from `profile/README.md`.
+
+## Files and their effect
+
+- `profile/README.md` — Rendered publicly on the organization's GitHub profile page
+  (`github.com/nemtus`). This is the most visible file; edits change what visitors see. Keep the
+  cross-repo links to NEMTUS projects (SDKs, Hackathon, Tech Fest, blogs, techbooks) accurate.
+- `FUNDING.yml` — Drives the "Sponsor" button across org repos. Only `github: [nemtus]` is active;
+  the other platforms are commented placeholders.
+- `README.md` — Describes the repo itself (not org-facing). Recent git history shows this is the
+  file most often touched.
+- `LICENSE` — MIT.
+
+Note: `README.md` (repo-level) and `profile/README.md` (org profile) are distinct and serve
+different audiences — don't conflate them when editing.
+
+## Working conventions
+
+- The default branch is `main`; changes typically land via PR (see existing merged PRs in history).
+- When updating project links in `profile/README.md`, verify the target repos/sites still exist,
+  since these are external references that drift over time.


### PR DESCRIPTION
Add Claude Code configuration for this organization-level `.github` repository.

- Add `CLAUDE.md` describing the repo as GitHub's org-level `.github` repository (docs/config only, no build tooling) and the role of each file.
- Add a shared `.claude/settings.json` defining allow/ask/deny command permissions.
- Ignore `.op/` (1Password CLI local plugin state) in `.gitignore`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repository guidance for working in this project, including key file references and contribution conventions.

* **Chores**
  * Updated local ignore rules and added assistant configuration for safer, more controlled file and command access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->