### PR TITLE
docs: Document running gh via the 1Password plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,10 +11,10 @@
       "Bash(ls:*)",
       "Bash(find:*)",
       "Bash(rg:*)",
-      "Bash(gh pr view:*)",
-      "Bash(gh pr list:*)",
-      "Bash(gh pr diff:*)",
-      "Bash(gh repo view:*)",
+      "Bash(op plugin run -- gh pr view:*)",
+      "Bash(op plugin run -- gh pr list:*)",
+      "Bash(op plugin run -- gh pr diff:*)",
+      "Bash(op plugin run -- gh repo view:*)",
       "Edit(*.md)",
       "Edit(profile/*.md)",
       "Edit(*.yml)",
@@ -23,8 +23,8 @@
     "ask": [
       "Bash(git commit:*)",
       "Bash(git push:*)",
-      "Bash(gh pr create:*)",
-      "Bash(gh pr merge:*)",
+      "Bash(op plugin run -- gh pr create:*)",
+      "Bash(op plugin run -- gh pr merge:*)",
       "WebFetch"
     ],
     "deny": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,3 +30,17 @@ different audiences — don't conflate them when editing.
 - The default branch is `main`; changes typically land via PR (see existing merged PRs in history).
 - When updating project links in `profile/README.md`, verify the target repos/sites still exist,
   since these are external references that drift over time.
+
+## Running `gh` in this environment
+
+The maintainer authenticates the GitHub CLI through the 1Password CLI shell plugin. The bare `gh`
+command is an interactive-shell alias (`gh="op plugin run -- gh"`) and is therefore **unauthenticated
+in non-interactive shells** (the alias isn't loaded). To run authenticated GitHub CLI commands —
+including from automation — invoke the wrapper explicitly:
+
+```
+op plugin run -- gh <args>      # e.g. op plugin run -- gh pr create ...
+```
+
+Do not add a `gh` PATH shim for this: `op plugin run -- gh` spawns `gh` as a child process, so a shim
+earlier in `PATH` would recurse infinitely. Always call `op plugin run -- gh` directly instead.


### PR DESCRIPTION
Follow-up to the Claude Code config setup.

In this environment the GitHub CLI is authenticated through the 1Password CLI shell plugin, where bare `gh` is an interactive-shell alias for `op plugin run -- gh`. In non-interactive shells (e.g. automation) the alias is not loaded, so bare `gh` runs unauthenticated and fails.

- `CLAUDE.md`: document that authenticated GitHub CLI commands must be invoked as `op plugin run -- gh ...`, and warn against a `gh` PATH shim (it would recurse, since `op plugin run -- gh` spawns `gh` as a child).
- `.claude/settings.json`: permit only the `op plugin run -- gh` forms (read-only ones in `allow`, `pr create`/`pr merge` in `ask`) and drop the bare `gh` entries, which only ever fail unauthenticated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)