### PR TITLE
chore: Add multi-root workspace config for nemtus repos

### DIFF
--- a/nemtus.code-workspace
+++ b/nemtus.code-workspace
@@ -1,0 +1,50 @@
+{
+  "folders": [
+    { "path": ".", "name": "org-meta (.github)" },
+    { "path": "../symbol" }
+  ],
+  "settings": {
+    // Watcher excludes: most important here since this does NOT honor .gitignore
+    // (keeps catapult's _build and node_modules from overloading the file watcher).
+    "files.watcherExclude": {
+      "**/.git/**": true,
+      "**/node_modules/**": true,
+      "**/_build/**": true,
+      "**/_temp/**": true,
+      "**/dist/**": true,
+      "**/build/**": true,
+      "**/ts/**": true,
+      "**/__pycache__/**": true,
+      "**/*.egg-info/**": true,
+      "**/.pytest_cache/**": true,
+      "**/.mypy_cache/**": true,
+      "**/.ruff_cache/**": true,
+      "**/.venv/**": true,
+      "**/coverage/**": true,
+      "**/htmlcov/**": true
+    },
+    // Search excludes: keep generated artifacts out of search results (still shown in Explorer).
+    "search.exclude": {
+      "**/node_modules": true,
+      "**/_build": true,
+      "**/_temp": true,
+      "**/dist": true,
+      "**/build": true,
+      "**/ts": true,
+      "**/__pycache__": true,
+      "**/*.egg-info": true,
+      "**/.pytest_cache": true,
+      "**/.mypy_cache": true,
+      "**/.ruff_cache": true,
+      "**/.venv": true,
+      "**/coverage": true,
+      "**/htmlcov": true,
+      "**/package-lock.json": true
+    },
+    // Explorer hides only minimal noise (generated dirs stay visible): OS cruft and the 1Password secrets dir.
+    "files.exclude": {
+      "**/.DS_Store": true,
+      "**/.op": true
+    }
+  }
+}


### PR DESCRIPTION
## What

Add `nemtus.code-workspace`, a VS Code multi-root workspace bundling the `.github` and `symbol` repositories, so work spanning multiple nemtus org repos can share one workspace. Starts with just these two folders.

## Settings

Tuned for the polyglot `symbol` monorepo (C++ catapult, Node/TS SDK + rest client, Python SDK + catbuffer):

- **`files.watcherExclude`** (most impactful — does not honor `.gitignore`) and **`search.exclude`** drop generated artifacts: `_build`, `_temp`, `node_modules`, `ts`, `__pycache__`, `*.egg-info`, `dist`, `build`, and common caches.
- **`files.exclude`** is kept minimal so generated dirs stay visible in the Explorer — it only hides OS cruft (`.DS_Store`) and the local 1Password `.op` secrets dir.

## Verify

1. Open via **File > Open Workspace from File…**, confirm it parses as valid JSONC.
2. Search (Cmd/Ctrl+Shift+F) — `node_modules` / `__pycache__` etc. should not appear.
3. Explorer still shows generated dirs under `symbol`; `.op` is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a VS Code workspace configuration for easier local development across the main project and a related folder.
  * Improved editor and search behavior by excluding generated files and other noisy artifacts, keeping navigation cleaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->