### PR TITLE
docs: Add Python PyPI packages to profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -29,7 +29,7 @@ images, hands-on events, and a welcoming community.
 
 ## 🧰 Build on Symbol
 
-TypeScript-first libraries for building Symbol apps:
+Libraries for building Symbol apps, in JavaScript/TypeScript and Python:
 
 | Package | What it is | Links |
 | --- | --- | --- |
@@ -37,6 +37,8 @@ TypeScript-first libraries for building Symbol apps:
 | **@nemtus/symbol-openapi** | OpenAPI specification of the Symbol (catapult) REST API | [npm](https://www.npmjs.com/package/@nemtus/symbol-openapi) ![npm](https://img.shields.io/npm/v/@nemtus/symbol-openapi) · [GitHub](https://github.com/nemtus/symbol) |
 | **@nemtus/symbol-sdk-openapi-generator-typescript-axios** | Typed REST client generated for Axios | [npm](https://www.npmjs.com/package/@nemtus/symbol-sdk-openapi-generator-typescript-axios) ![npm](https://img.shields.io/npm/v/@nemtus/symbol-sdk-openapi-generator-typescript-axios) · [GitHub](https://github.com/nemtus/symbol-sdk-openapi-generator-typescript-axios) |
 | **@nemtus/symbol-sdk-openapi-generator-typescript-fetch** | Typed REST client generated for Fetch | [npm](https://www.npmjs.com/package/@nemtus/symbol-sdk-openapi-generator-typescript-fetch) ![npm](https://img.shields.io/npm/v/@nemtus/symbol-sdk-openapi-generator-typescript-fetch) · [GitHub](https://github.com/nemtus/symbol-sdk-openapi-generator-typescript-fetch) |
+| **nemtus-symbol-sdk** | Symbol Python SDK (import module: `symbolchain`) | [PyPI](https://pypi.org/project/nemtus-symbol-sdk/) ![PyPI](https://img.shields.io/pypi/v/nemtus-symbol-sdk) · [GitHub](https://github.com/nemtus/symbol/tree/dev/sdk/python) |
+| **nemtus-catparser** | Symbol catbuffer schema parser (Python) | [PyPI](https://pypi.org/project/nemtus-catparser/) ![PyPI](https://img.shields.io/pypi/v/nemtus-catparser) · [GitHub](https://github.com/nemtus/symbol/tree/dev/catbuffer/parser) |
 
 > ℹ️ `@nemtus/symbol-sdk-typescript` is **deprecated** — please migrate to **@nemtus/symbol-sdk**.
 


### PR DESCRIPTION
## What

Add the two Python packages newly published to PyPI to the **Build on Symbol** package list in `profile/README.md`:

| Package | What it is |
| --- | --- |
| **nemtus-symbol-sdk** | Symbol Python SDK (import module: `symbolchain`) |
| **nemtus-catparser** | Symbol catbuffer schema parser (Python) |

Also broadened the section intro from "TypeScript-first libraries" to cover both JavaScript/TypeScript and Python, now that Python packages are available.

## Why

The `nemtus/symbol` repository now publishes `nemtus-symbol-sdk` and `nemtus-catparser` to PyPI. This keeps the org profile's package list accurate.

## Notes

- Both packages verified to exist on PyPI via the JSON API (versions `3.3.2.post1` and `3.2.0.post1`).
- Each row follows the existing npm entry style (registry link + version badge + GitHub link). GitHub links point to the upstream source dirs in `nemtus/symbol`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)