### PR TITLE
chore: Add symbol-product to workspace config

### DIFF
--- a/nemtus.code-workspace
+++ b/nemtus.code-workspace
@@ -1,7 +1,8 @@
 {
   "folders": [
     { "path": ".", "name": "org-meta (.github)" },
-    { "path": "../symbol" }
+    { "path": "../symbol" },
+    { "path": "../symbol-product" }
   ],
   "settings": {
     // Watcher excludes: most important here since this does NOT honor .gitignore


### PR DESCRIPTION
Add the `symbol-product` repo as a root folder in `nemtus.code-workspace` so it opens alongside `.github` and `symbol` in VS Code.

The sibling `../symbol-product` directory exists, and the existing `settings` excludes already cover its generated artifacts, so no other changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the workspace setup to include an additional project folder, making it easier to work across both projects in one editor session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->