### PR TITLE
chore: Add symbol-networks to workspace config

### DIFF
--- a/nemtus.code-workspace
+++ b/nemtus.code-workspace
@@ -2,6 +2,7 @@
   "folders": [
     { "path": ".", "name": "org-meta (.github)" },
     { "path": "../symbol" },
+    { "path": "../symbol-networks" },
     { "path": "../symbol-product" }
   ],
   "settings": {


### PR DESCRIPTION
## Summary
- Add the upcoming `nemtus/symbol-networks` repo as a folder in `nemtus.code-workspace`, placed alphabetically between `../symbol` and `../symbol-product`.

The directory already exists locally as a sibling and work has started; this wires it into the multi-root VS Code workspace so it shows up alongside the other Symbol repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an additional workspace folder to the development workspace, making another project directory available alongside the existing ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->