### PR TITLE
chore: Add nemtus org-root folder to workspace config

### DIFF
--- a/nemtus.code-workspace
+++ b/nemtus.code-workspace
@@ -1,5 +1,6 @@
 {
   "folders": [
+    { "path": "..", "name": "org-root" },
     { "path": ".", "name": "org-meta (.github)" },
     { "path": "../symbol" },
     { "path": "../symbol-networks" },


### PR DESCRIPTION
## Summary

Adds the `nemtus` org directory (`..`) to the VS Code multi-root workspace as a folder named `org-root`, so the whole organization root is visible alongside the individual repos.

## Changes

- `nemtus.code-workspace`: add `{ "path": "..", "name": "org-root" }` as the first folder entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workspace setup to include an additional top-level folder, making it easier to open and navigate the broader project in VS Code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->