### PR TITLE
docs: Point hackathon LP table to nemtus/apps monorepo

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -75,14 +75,17 @@ Our flagship annual hackathon for builders on Symbol, held every year since 2022
 
 - **Hackathon app** — registration & event management, built on Symbol and actively maintained:
   **[Open app](https://nemtus-hackathon.web.app/)** · [GitHub](https://github.com/nemtus/hackathon)
-- **All editions** — [overview site](https://hackathon.nemtus.com/) ([repo](https://github.com/nemtus/hackathon-lp)):
+- **All editions** — [overview site](https://hackathon.nemtus.com/)
+  ([repo](https://github.com/nemtus/apps/tree/main/apps/hackathon-lp)). The overview and the
+  2023–2026 landing pages now live in the [`nemtus/apps`](https://github.com/nemtus/apps) monorepo
+  and deploy on Cloudflare Workers:
 
   | Edition | Website | Source |
   | --- | --- | --- |
-  | HACK+2026 | [hackathon-2026.nemtus.com](https://hackathon-2026.nemtus.com/) | — |
-  | HACK+2025 | [hackathon-2025.nemtus.com](https://hackathon-2025.nemtus.com/) | [GitHub](https://github.com/nemtus/hackathon-lp-2025) |
-  | HACK+2024 | [hackathon-2024.nemtus.com](https://hackathon-2024.nemtus.com/) | [GitHub](https://github.com/nemtus/hackathon-lp-2024) |
-  | HACK+2023 | [hackathon-2023.nemtus.com](https://hackathon-2023.nemtus.com/) | [GitHub](https://github.com/nemtus/hackathon-lp-2023) |
+  | HACK+2026 | [hackathon-2026.nemtus.com](https://hackathon-2026.nemtus.com/) | [GitHub](https://github.com/nemtus/apps/tree/main/apps/hackathon-lp-2026) |
+  | HACK+2025 | [hackathon-2025.nemtus.com](https://hackathon-2025.nemtus.com/) | [GitHub](https://github.com/nemtus/apps/tree/main/apps/hackathon-lp-2025) |
+  | HACK+2024 | [hackathon-2024.nemtus.com](https://hackathon-2024.nemtus.com/) | [GitHub](https://github.com/nemtus/apps/tree/main/apps/hackathon-lp-2024) |
+  | HACK+2023 | [hackathon-2023.nemtus.com](https://hackathon-2023.nemtus.com/) | [GitHub](https://github.com/nemtus/apps/tree/main/apps/hackathon-lp-2023) |
   | HACK+2022 | [hackathon-2022.nemtus.com](https://hackathon-2022.nemtus.com/) | — |
 
 ## 🎓 Learn Symbol


### PR DESCRIPTION
## Summary

The hackathon landing pages have been consolidated into the [`nemtus/apps`](https://github.com/nemtus/apps) monorepo and re-platformed onto **Cloudflare Workers**. This updates the HACK+ editions table in `profile/README.md` to match.

## Changes

- **Source links** for HACK+2023–2026 now point at their subdirectories in `nemtus/apps` (`apps/hackathon-lp-2023` … `apps/hackathon-lp-2026`) instead of the retired standalone `hackathon-lp-YYYY` repos.
- **HACK+2026** previously had no Source (`—`); it is now tracked in the monorepo, so it links to `apps/hackathon-lp-2026`.
- The **overview site** repo link now points to `apps/hackathon-lp`, and a note calls out that these pages live in `nemtus/apps` and deploy on Cloudflare Workers.
- **HACK+2022** was not migrated and keeps its `—` source.

Website URLs (`hackathon-YYYY.nemtus.com`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)